### PR TITLE
#54 Fix version display showing extra .0 suffix

### DIFF
--- a/src/Service/DiscoToolbarService.php
+++ b/src/Service/DiscoToolbarService.php
@@ -183,7 +183,7 @@ class DiscoToolbarService
     {
         $version = null;
         try {
-            $version = InstalledVersions::getVersion('marcin-orlowski/disco-toolbar-symfony');
+            $version = InstalledVersions::getPrettyVersion('marcin-orlowski/disco-toolbar-symfony');
         } catch (\Exception) {
             // do nothing
         }


### PR DESCRIPTION
## Summary
- Use `getPrettyVersion()` instead of `getVersion()` to return the original version string

Closes #54