### PR TITLE
#53 Add support for Symfony UX Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ widgets:
 |-------------|:--------:|:--------:|---------------------------------------------------------------------------------|
 | `type`      | `string` |          | Widget type: `link` (default) or `close` (dismisses toolbar).                   |
 | `icon`*     | `string` |          | Optional icon to display. Can be Font Awesome class or emoji/text.              |
-| `icon_type` | `string` |          | Icon type: `fa` (Font Awesome, default) or `text` (emoji/plain text).           |
+| `icon_type` | `string` |          | Icon type: `fa` (Font Awesome, default), `ux` (Symfony UX Icons), or `text`.    |
 | `text`*     | `string` |          | Optional widget label to display alongside icon.                                |
 | `url`       | `string` |    *     | Link URL to redirect to once widget is clicked.                                 |
 | `target`    | `string` |          | Link target (e.g., `_blank`). Default: no target                                |
@@ -194,6 +194,38 @@ widgets:
       icon_type: "text"  # Use plain text/emoji
       url: "/admin"
 ```
+
+### Symfony UX Icons
+
+DiscoToolbar supports [Symfony UX Icons](https://ux.symfony.com/icons), which provides access to
+200,000+ icons from popular icon sets (Lucide, Heroicons, Font Awesome, and more) as inline SVGs.
+
+First, install the UX Icons package:
+
+```bash
+composer require symfony/ux-icons
+```
+
+Then use the `ux` icon type with icon names in the `set:name` format:
+
+```yaml
+widgets:
+  left:
+    - icon: "lucide:github"
+      icon_type: "ux"
+      url: "https://github.com"
+    - icon: "heroicons:home"
+      icon_type: "ux"
+      url: "/"
+    - icon: "fa6-solid:database"
+      icon_type: "ux"
+      url: "http://localhost:8080"
+```
+
+Browse available icons at [ux.symfony.com/icons](https://ux.symfony.com/icons).
+
+**Note:** If `symfony/ux-icons` is not installed, widgets with `icon_type: ux` will display
+the icon name in brackets as a fallback (e.g., `[lucide:github]`).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ startup, ensuring all links always point to the correct ports and services.
 ## Features
 
 - **Fully customizable via YAML** - Easy to configure and regenerate for different environments
-- **Flexible widget system** - Create buttons with Font Awesome icons, emoji, text labels, or any combination
+- **Flexible widget system** - Create buttons with Font Awesome icons, Symfony UX Icons, emoji, text labels, or any combination
 - **Display anything** - Add links to admin panels, database tools, email catchers, API docs, or any resource
 - **Action buttons** - Direct access to frequently-used tools and services
 - **Environment-aware** - Only loads in development environment, zero production overhead
@@ -44,6 +44,10 @@ startup, ensuring all links always point to the correct ports and services.
 
 - PHP 8.1 or higher
 - Symfony 6.4+, 7.0+, or 8.0+
+
+### Optional Dependencies
+
+- [`symfony/ux-icons`](https://symfony.com/bundles/ux-icons/current/index.html) - Required for `icon_type: ux` support (200,000+ icons)
 
 ### Notes
 
@@ -57,6 +61,12 @@ Install via Composer:
 
 ```bash
 composer require --dev marcin-orlowski/disco-toolbar-symfony
+```
+
+For access to 200,000+ icons via [Symfony UX Icons](https://ux.symfony.com/icons) (recommended):
+
+```bash
+composer require symfony/ux-icons
 ```
 
 Register the bundle in `config/bundles.php`:
@@ -123,7 +133,7 @@ widgets:
 | Property    |   Type   | Required | Description                                                                     |
 |-------------|:--------:|:--------:|---------------------------------------------------------------------------------|
 | `type`      | `string` |          | Widget type: `link` (default) or `close` (dismisses toolbar).                   |
-| `icon`*     | `string` |          | Optional icon to display. Can be Font Awesome class or emoji/text.              |
+| `icon`*     | `string` |          | Optional icon to display (Font Awesome class, UX Icons name, or emoji/text).    |
 | `icon_type` | `string` |          | Icon type: `fa` (Font Awesome, default), `ux` (Symfony UX Icons), or `text`.    |
 | `text`*     | `string` |          | Optional widget label to display alongside icon.                                |
 | `url`       | `string` |    *     | Link URL to redirect to once widget is clicked.                                 |

--- a/Resources/views/toolbar.html.twig
+++ b/Resources/views/toolbar.html.twig
@@ -44,7 +44,9 @@
                                {% if widget.title %}title="{{ widget.title }}"{% endif %}>
                                 <span class="disco-toolbar-link-content">
                                     {% if widget.icon %}
-                                        {% if widget.iconType.value == 'fa' %}
+                                        {% if widget.iconType.value == 'ux' %}
+                                            {{ disco_ux_icon(widget.icon) }}
+                                        {% elseif widget.iconType.value == 'fa' %}
                                             <i class="fa-solid {{ widget.icon }}"></i>
                                         {% else %}
                                             {{ widget.icon }}
@@ -76,7 +78,9 @@
                                {% if widget.title %}title="{{ widget.title }}"{% endif %}>
                                 <span class="disco-toolbar-link-content">
                                     {% if widget.icon %}
-                                        {% if widget.iconType.value == 'fa' %}
+                                        {% if widget.iconType.value == 'ux' %}
+                                            {{ disco_ux_icon(widget.icon) }}
+                                        {% elseif widget.iconType.value == 'fa' %}
                                             <i class="fa-solid {{ widget.icon }}"></i>
                                         {% else %}
                                             {{ widget.icon }}

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
     "phpstan/phpstan-symfony": "^2.0",
     "squizlabs/php_codesniffer": "^3.13"
   },
+  "suggest": {
+    "symfony/ux-icons": "Required for icon_type: ux support"
+  },
   "autoload": {
     "psr-4": {
       "MarcinOrlowski\\DiscoToolbar\\": "src/"

--- a/src/Dto/IconType.php
+++ b/src/Dto/IconType.php
@@ -24,4 +24,5 @@ enum IconType: string
 {
     case FONT_AWESOME = 'fa';
     case TEXT = 'text';
+    case UX_ICONS = 'ux';
 }

--- a/src/Twig/DiscoToolbarExtension.php
+++ b/src/Twig/DiscoToolbarExtension.php
@@ -70,15 +70,9 @@ class DiscoToolbarExtension extends AbstractExtension
     public function renderUxIcon(string $icon): Markup|string
     {
         try {
-            $function = $this->twig->getFunction('ux_icon');
-            if ($function !== null) {
-                $callable = $function->getCallable();
-                if (\is_callable($callable)) {
-                    $result = $callable($icon);
-                    if ($result instanceof Markup || \is_string($result)) {
-                        return $result;
-                    }
-                }
+            if ($this->twig->getFunction('ux_icon') !== null) {
+                $template = $this->twig->createTemplate('{{ ux_icon(icon) }}');
+                return new Markup($template->render(['icon' => $icon]), 'UTF-8');
             }
         } catch (\Exception) {
             // ux_icon function not available

--- a/src/Twig/DiscoToolbarExtension.php
+++ b/src/Twig/DiscoToolbarExtension.php
@@ -21,7 +21,9 @@ declare(strict_types=1);
 namespace MarcinOrlowski\DiscoToolbar\Twig;
 
 use MarcinOrlowski\DiscoToolbar\Service\DiscoToolbarService;
+use Twig\Environment;
 use Twig\Extension\AbstractExtension;
+use Twig\Markup;
 use Twig\TwigFunction;
 
 /**
@@ -30,7 +32,8 @@ use Twig\TwigFunction;
 class DiscoToolbarExtension extends AbstractExtension
 {
     public function __construct(
-        private readonly DiscoToolbarService $discoToolbarService
+        private readonly DiscoToolbarService $discoToolbarService,
+        private readonly Environment $twig
     ) {
     }
 
@@ -46,6 +49,10 @@ class DiscoToolbarExtension extends AbstractExtension
                 $this,
                 'getDiscoToolbarData',
             ]),
+            new TwigFunction('disco_ux_icon', [
+                $this,
+                'renderUxIcon',
+            ], ['is_safe' => ['html']]),
         ];
     }
 
@@ -55,5 +62,28 @@ class DiscoToolbarExtension extends AbstractExtension
     public function getDiscoToolbarData(): \MarcinOrlowski\DiscoToolbar\Dto\DiscoToolbarData
     {
         return $this->discoToolbarService->getDiscoToolbarData();
+    }
+
+    /**
+     * Renders a UX Icon if symfony/ux-icons is installed, otherwise returns fallback
+     */
+    public function renderUxIcon(string $icon): Markup|string
+    {
+        try {
+            $function = $this->twig->getFunction('ux_icon');
+            if ($function !== null) {
+                $callable = $function->getCallable();
+                if (\is_callable($callable)) {
+                    $result = $callable($icon);
+                    if ($result instanceof Markup || \is_string($result)) {
+                        return $result;
+                    }
+                }
+            }
+        } catch (\Exception) {
+            // ux_icon function not available
+        }
+
+        return \sprintf('[%s]', \htmlspecialchars($icon, \ENT_QUOTES, 'UTF-8'));
     }
 }


### PR DESCRIPTION
## Summary
- Added `icon_type: ux` support for Symfony UX Icons
- Created `disco_ux_icon()` wrapper with graceful fallback when package not installed
- Added `symfony/ux-icons` as suggested dependency in composer.json
- Updated documentation with installation and usage instructions

Closes #53