### PR TITLE
#51 Add config/packages/disco_toolbar.yaml as config location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - [#054] Fixed version displayed as `2.0.0.0` instead of `2.0.0` when config file is missing
 - [#053] Added support for Symfony's UX-Icons: https://ux.symfony.com/icons
+- [#051] Added support for `config/packages/disco_toolbar.yaml` config location
 
 ## 2.0.0 (2026-01-30)
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ php bin/console assets:install --symlink
 
 ## Configuration
 
-Create a configuration file in your project root with widget configuration. The bundle will automatically
+Create a configuration file with widget configuration. The bundle will automatically
 detect and load the first file found (in order of preference):
 
-- `.disco.yaml` (recommended)
-- `.disco.yml`
+- `.disco.yaml` (project root)
+- `.disco.yml` (project root)
+- `config/packages/disco_toolbar.yaml` (Symfony convention)
+- `config/packages/disco_toolbar.yml`
 
 Example configuration that produces toolbar shown in the screenshot above:
 

--- a/src/Service/DiscoToolbarService.php
+++ b/src/Service/DiscoToolbarService.php
@@ -28,11 +28,13 @@ use Symfony\Component\Yaml\Yaml;
 class DiscoToolbarService
 {
     /**
-     * List of supported config filenames (in order of preference)
+     * List of supported config paths (in order of preference)
      */
-    private const CONFIG_FILES = [
+    private const CONFIG_PATHS = [
         '.disco.yaml',
         '.disco.yml',
+        'config/packages/disco_toolbar.yaml',
+        'config/packages/disco_toolbar.yml',
     ];
 
     /**
@@ -58,7 +60,7 @@ class DiscoToolbarService
 
         // Default: show error message when no config found
         if ($configPath === null) {
-            $errorMessage = 'Config file not found: ' . self::CONFIG_FILES[0];
+            $errorMessage = 'Config file not found. Create ' . self::CONFIG_PATHS[0];
             return new DiscoToolbarData(
                 left:                [],
                 right:               [],
@@ -125,14 +127,14 @@ class DiscoToolbarService
     }
 
     /**
-     * Find the first existing config file from the list of supported filenames
+     * Find the first existing config file from the list of supported paths
      *
      * @return string|null Full path to config file or null if none found
      */
     private function findConfigFile(): ?string
     {
-        foreach (self::CONFIG_FILES as $filename) {
-            $path = $this->projectDir . '/' . $filename;
+        foreach (self::CONFIG_PATHS as $configPath) {
+            $path = $this->projectDir . '/' . $configPath;
             if (\file_exists($path)) {
                 return $path;
             }


### PR DESCRIPTION
## Summary
- Added `config/packages/disco_toolbar.yaml` as supported config location (Symfony convention)
- Config is now searched in this order: `.disco.yaml`, `.disco.yml`, `config/packages/disco_toolbar.yaml`, `config/packages/disco_toolbar.yml`
- Updated documentation

Closes #51