### PR TITLE
#7 Improve layout of entries with long titles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ## 2.1.0 (TBD)
 
+- [#007] Improved layout of expandable widgets with long titles by adding fade-out effect
 - [#054] Fixed version displayed as `2.0.0.0` instead of `2.0.0` when config file is missing
 - [#053] Added support for Symfony's UX-Icons: https://ux.symfony.com/icons
 - [#051] Added support for `config/packages/disco_toolbar.yaml` config location

--- a/Resources/public/toolbar.css
+++ b/Resources/public/toolbar.css
@@ -117,6 +117,22 @@
 .disco-toolbar-widget-expand {
     flex: 1 1 0;
     min-width: 0;
+    overflow: hidden;
+}
+
+/* Expandable widget link - fills container width */
+.disco-toolbar-widget-expand .disco-toolbar-link {
+    width: 100%;
+    overflow: hidden;
+}
+
+/* Expandable widget content - fade out effect on right edge */
+.disco-toolbar-widget-expand .disco-toolbar-link-content {
+    overflow: hidden;
+    padding-right: 24px;
+    mask-image: linear-gradient(to right, black calc(100% - 50px), transparent 100%);
+    /* stylelint-disable-next-line property-no-vendor-prefix -- Safari compatibility */
+    -webkit-mask-image: linear-gradient(to right, black calc(100% - 50px), transparent 100%);
 }
 
 /* DiscoDevBar links */


### PR DESCRIPTION
## Summary

- Added fade-out gradient effect on the right edge of expandable widget text (last 50px fades to transparent)
- Added extra right padding (24px) for better spacing between title text and following elements
- Prevents long titles from visually crowding adjacent icons/buttons

Closes #7